### PR TITLE
Bugfix/move cross env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All changes to the project will be documented in this file.
 
+## [1.0.2] - 2021-12-02
+### Moved
+- `cross-env` to `dependencies` and `webpack` to `devDependencies`
+
+
 ## [1.0.1] - 2021-12-01
 ### Updated
 - most existing packages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "christmas-list",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@editorjs/table": "^1.3.0",
     "@editorjs/underline": "^1.0.0",
     "bcryptjs": "^2.3.0",
+    "cross-env": "^5.2.0",
     "dotenv": "^8.2.0",
     "editorjs-paragraph-with-alignment": "^1.1.0",
     "express": "^4.17.1",
@@ -46,7 +47,6 @@
     "react-editor-js": "^1.7.0",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
-    "webpack": "^4.29.3"
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",
@@ -54,7 +54,6 @@
     "@babel/preset-react": "^7.10.4",
     "babel-loader": "^8.1.0",
     "concurrently": "^6.3.0",
-    "cross-env": "^5.2.0",
     "css-loader": "^3.6.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.4",
@@ -74,6 +73,7 @@
     "sass-loader": "^9.0.2",
     "style-loader": "^1.2.1",
     "url-loader": "^4.1.0",
+    "webpack": "^4.29.3",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.11.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "christmas-list",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "./client/index.js",
   "scripts": {


### PR DESCRIPTION
This is probably best practices anyway, but since Heroku removes devDependencies after building, cross-env was not getting installed, which seemed to be causing problems with starting the app.

This PR also moves webpack to devDependencies since it's not used during runtime.